### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,7 @@ jobs:
          distribution: 'adopt'
          cache: 'gradle'
      - name: Publish to Registry
-       uses: elgohr/Publish-Docker-Github-Action@master
+       uses: elgohr/Publish-Docker-Github-Action@v5
        with:
         name: unreal/apollostats
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore